### PR TITLE
fix: enable gold deposit, withdraw from bank and other UI text submission when pursuit_id=0

### DIFF
--- a/src/slint_support/callbacks/game_callbacks.rs
+++ b/src/slint_support/callbacks/game_callbacks.rs
@@ -69,8 +69,6 @@ pub fn wire_game_callbacks(slint_app: &MainWindow, tx: Sender<UiToCore>) {
         let tx = tx.clone();
         let slint_app_weak = slint_app.as_weak();
         npc_dialog.on_submit_text(move |text: slint::SharedString| {
-            tracing::debug!("🔍 submit-text callback triggered with text parameter: '{}'", text);
-
             if let Some(app) = slint_app_weak.upgrade() {
                 let npc = app.global::<NpcDialogState>();
                 npc.set_text_entry_visible(false);

--- a/src/webui/plugin.rs
+++ b/src/webui/plugin.rs
@@ -199,10 +199,6 @@ fn handle_ui_inbound_ingame(
                 });
             }
             UiToCore::MenuSelect { id, name } => {
-                tracing::info!("🔍 MenuSelect received: id={}, name='{}', name.len={}", id, name, name.len());
-                tracing::info!("🔍 Menu context: window_type={:?}, pursuit_id={}, dialog_id={:?}, menu_type={:?}, args='{}'",
-                    menu_ctx.window_type, menu_ctx.pursuit_id, menu_ctx.dialog_id, menu_ctx.menu_type, menu_ctx.args);
-
                 if menu_ctx.window_type == ActiveWindowType::Info {
                     menu_ctx.window_type = ActiveWindowType::None;
                     outbound.write(UiOutbound(CoreToUi::DisplayMenuClose));
@@ -245,21 +241,15 @@ fn handle_ui_inbound_ingame(
                     );
 
                     let args = if is_slot_interaction {
-                        tracing::debug!("🔍 Slot interaction, sending slot: {}", *id);
                         packets::client::MenuInteractionArgs::Slot(*id as u8)
                     } else {
                         let mut topics = Vec::new();
                         if !menu_ctx.args.is_empty() {
-                            tracing::debug!("🔍 Adding menu_ctx.args to topics: '{}'", menu_ctx.args);
                             topics.push(menu_ctx.args.clone());
                         }
                         if !name.is_empty() {
-                            tracing::debug!("🔍 Adding name to topics: '{}'", name);
                             topics.push(name.clone());
-                        } else {
-                            tracing::warn!("🔍 name is EMPTY! This will likely fail.");
                         }
-                        tracing::debug!("🔍 Final topics vector: {:?}", topics);
                         packets::client::MenuInteractionArgs::Topics(topics)
                     };
 
@@ -269,33 +259,25 @@ fn handle_ui_inbound_ingame(
                     let args = if !menu_ctx.args.is_empty() || !name.is_empty() {
                         let mut topics = Vec::new();
                         if !menu_ctx.args.is_empty() {
-                            tracing::debug!("🔍 (else branch) Adding menu_ctx.args to topics: '{}'", menu_ctx.args);
                             topics.push(menu_ctx.args.clone());
                         }
                         if !name.is_empty() {
-                            tracing::debug!("🔍 (else branch) Adding name to topics: '{}'", name);
                             topics.push(name.clone());
                         }
-                        tracing::debug!("🔍 (else branch) Final topics vector: {:?}", topics);
                         packets::client::MenuInteractionArgs::Topics(topics)
                     } else {
-                        tracing::warn!("🔍 (else branch) Both args and name are EMPTY, using Slot(0)");
                         packets::client::MenuInteractionArgs::Slot(0)
                     };
                     (pursuit_id, args)
                 };
 
                 if let Some(entity_type) = menu_ctx.entity_type {
-                    tracing::debug!("🔍 Sending MenuInteraction packet: entity_type={:?}, entity_id={}, pursuit_id={}, args={:?}",
-                        entity_type, menu_ctx.entity_id, pursuit_id, args);
                     outbox.send(&packets::client::MenuInteraction {
                         entity_type,
                         entity_id: menu_ctx.entity_id,
                         pursuit_id,
                         args,
                     });
-                } else {
-                    tracing::error!("🔍 Cannot send MenuInteraction: entity_type is None!");
                 }
             }
             UiToCore::MenuClose => {


### PR DESCRIPTION
i believe also fixes https://github.com/talgonite/talgonite/issues/24

debug logs before:
```
2026-02-06T06:38:34.242391Z  INFO Received DisplayMenu: DisplayMenu { menu_type: Menu, header: DisplayMenuHeader { entity_type: Creature, source_id: 242896600, sprite: 56, color: 0, should_illustrate: false, name: "Cecil", text: "Hello, Aisling. How may I help you?" }, payload: Menu { options: [("Deposit Item", 52), ("Withdraw Item", 55), ("Deposit Gold", 57), ("Withdraw Gold", 59)] } }
2026-02-06T06:38:38.008974Z  INFO 🔍 MenuSelect received: id=57, name='Deposit Gold', name.len=12
2026-02-06T06:38:38.009029Z  INFO 🔍 Menu context: window_type=Menu, pursuit_id=0, dialog_id=None, menu_type=Some(Menu), args=''
2026-02-06T06:38:38.009038Z  INFO 🔍 Sending MenuInteraction packet: entity_type=Creature, entity_id=242896600, pursuit_id=57, args=Slot(0)
2026-02-06T06:38:38.092286Z  INFO Received DisplayMenu: DisplayMenu { menu_type: TextEntry, header: DisplayMenuHeader { entity_type: Creature, source_id: 242896600, sprite: 56, color: 0, should_illustrate: false, name: "Cecil", text: "How much of your 120110 gold would you like to deposit?" }, payload: TextEntry { pursuit_id: 0 } }
2026-02-06T06:38:41.729829Z  INFO 🔍 submit-text callback triggered
2026-02-06T06:38:41.729861Z  INFO 🔍 text parameter: '1'
2026-02-06T06:38:41.729869Z  INFO 🔍 text.len(): 1
2026-02-06T06:38:41.729874Z  INFO 🔍 text.is_empty(): false
2026-02-06T06:38:41.729895Z  INFO 🔍 About to send MenuSelect with name: '1'
2026-02-06T06:38:41.729901Z  INFO 🔍 MenuSelect sent successfully
2026-02-06T06:38:41.742695Z  INFO 🔍 MenuSelect received: id=0, name='1', name.len=1
2026-02-06T06:38:41.742714Z  INFO 🔍 Menu context: window_type=Menu, pursuit_id=0, dialog_id=None, menu_type=Some(TextEntry), args=''
2026-02-06T06:38:41.742724Z  INFO 🔍 Sending MenuInteraction packet: entity_type=Creature, entity_id=242896600, pursuit_id=0, args=Slot(0)
2026-02-06T06:38:41.825782Z  INFO Received DisplayMenu: DisplayMenu { menu_type: Menu, header: DisplayMenuHeader { entity_type: Creature, source_id: 242896600, sprite: 56, color: 0, should_illustrate: false, name: "Cecil", text: "You don't have enough gold." }, payload: Menu { options: [] } }
```

debug logs success
```
2026-02-06T06:44:14.113938Z  INFO 🔍 Sending MenuInteraction packet: entity_type=Creature, entity_id=242896600, pursuit_id=0, args=Topics(["100"])
2026-02-06T06:44:14.380691Z  INFO Received DisplayMenu: DisplayMenu { menu_type: Menu, header: DisplayMenuHeader { entity_type: Creature, source_id: 242896600, sprite: 56, color: 0, should_illustrate: false, name: "Cecil", text: "Great! Your new total is 191500 gold." }, payload: Menu { options: [] } }
2026-02-06T06:44:37.064496Z  INFO Received DisplayMenu: DisplayMenu { menu_type: Menu, header: DisplayMenuHeader { entity_type: Creature, source_id: 242896600, sprite: 56, color: 0, should_illustrate: false, name: "Cecil", text: "Hello, Aisling. How may I help you?" }, payload: Menu { options: [("Deposit Item", 52), ("Withdraw Item", 55), ("Deposit Gold", 57), ("Withdraw Gold", 59)] } }
2026-02-06T06:44:39.614550Z  INFO 🔍 MenuSelect received: id=59, name='Withdraw Gold', name.len=13
2026-02-06T06:44:39.614614Z  INFO 🔍 Menu context: window_type=Menu, pursuit_id=0, dialog_id=None, menu_type=Some(Menu), args=''
2026-02-06T06:44:39.614625Z  INFO 🔍 (else branch) Adding name to topics: 'Withdraw Gold'
2026-02-06T06:44:39.614630Z  INFO 🔍 (else branch) Final topics vector: ["Withdraw Gold"]
2026-02-06T06:44:39.614637Z  INFO 🔍 Sending MenuInteraction packet: entity_type=Creature, entity_id=242896600, pursuit_id=59, args=Topics(["Withdraw Gold"])
2026-02-06T06:44:39.714368Z  INFO Received DisplayMenu: DisplayMenu { menu_type: TextEntry, header: DisplayMenuHeader { entity_type: Creature, source_id: 242896600, sprite: 56, color: 0, should_illustrate: false, name: "Cecil", text: "How much would you like to withdraw? You've got 191500 in your account." }, payload: TextEntry { pursuit_id: 0 } }
2026-02-06T06:44:44.319193Z  INFO 🔍 submit-text callback triggered
2026-02-06T06:44:44.319227Z  INFO 🔍 text parameter: '100'
2026-02-06T06:44:44.319233Z  INFO 🔍 text.len(): 3
2026-02-06T06:44:44.319238Z  INFO 🔍 text.is_empty(): false
2026-02-06T06:44:44.319255Z  INFO 🔍 About to send MenuSelect with name: '100'
2026-02-06T06:44:44.319263Z  INFO 🔍 MenuSelect sent successfully
2026-02-06T06:44:44.331205Z  INFO 🔍 MenuSelect received: id=0, name='100', name.len=3
2026-02-06T06:44:44.331232Z  INFO 🔍 Menu context: window_type=Menu, pursuit_id=0, dialog_id=None, menu_type=Some(TextEntry), args=''
2026-02-06T06:44:44.331244Z  INFO 🔍 (else branch) Adding name to topics: '100'
2026-02-06T06:44:44.331250Z  INFO 🔍 (else branch) Final topics vector: ["100"]
2026-02-06T06:44:44.331257Z  INFO 🔍 Sending MenuInteraction packet: entity_type=Creature, entity_id=242896600, pursuit_id=0, args=Topics(["100"])
2026-02-06T06:44:44.597710Z  INFO Received DisplayMenu: DisplayMenu { menu_type: Menu, header: DisplayMenuHeader { entity_type: Creature, source_id: 242896600, sprite: 56, color: 0, should_illustrate: false, name: "Cecil", text: "Great! I've now got 191400 gold for you." }, payload: Menu { options: [] } }
```