### PR TITLE
feat: display status effects in UI such as buffs/debuffs

### DIFF
--- a/game-ui/ui/components/game_scene.slint
+++ b/game-ui/ui/components/game_scene.slint
@@ -13,6 +13,7 @@ import { WorldMap } from "./world_map.slint";
 import { WorldLabels } from "./world_labels.slint";
 import { HotBar } from "./hot_bar.slint";
 import { PlayerHUD } from "./player_hud.slint";
+import { StatusEffectsBar } from "./status_effects_bar.slint";
 import { ActionBarMessages } from "./action_bar_messages.slint";
 import { ChatLog } from "./chat_log.slint";
 import { PopupPanel } from "./popup_panel.slint";
@@ -80,9 +81,22 @@ export component GameScene inherits Rectangle {
         height: 100%;
     }
 
-    player-hud := PlayerHUD {
+    HorizontalLayout {
         x: 20px;
-        y: 20px;
+
+        player-hud := PlayerHUD {
+            y: 20px;
+            min-width: 20px;
+        }
+
+        HorizontalLayout {
+            alignment: center;
+            padding-left: root.width * 5%;
+            padding-right: root.width * 25%;
+
+            // Displays buffs/debuffs active on current player
+            StatusEffectsBar {}
+        }
     }
 
     ActionBarMessages {

--- a/game-ui/ui/components/status_effects_bar.slint
+++ b/game-ui/ui/components/status_effects_bar.slint
@@ -1,0 +1,41 @@
+import { GameState } from "../game_state.slint";
+import { Theme } from "../theme.slint";
+
+export component StatusEffectsBar inherits Rectangle {
+    property <int> columns: 10;
+    property <length> slot-size: 30px;
+    property <length> gap: 4px;
+
+    width: (columns * slot-size) + ((columns - 1) * gap);
+    height: (slot-size * 2) + gap;
+
+    background: transparent;
+    opacity: 0.85;
+
+    for effect[idx] in GameState.status_effects: Rectangle {
+        property <color> bar-color: effect.bar-color;
+        property <float> duration-percent-remaining: effect.duration-percent-remaining;
+        width: slot-size;
+        height: slot-size;
+        x: Math.mod(idx, columns) * (slot-size + gap);
+        y: Math.floor(idx / columns) * (slot-size + gap);
+
+        effect-icon := Image {
+            source: effect.icon;
+            width: parent.width;
+            height: parent.height - 2px;
+            x: 0px;
+            y: 2px;
+        }
+
+        duration-bar := Rectangle {
+            // property <length> bar-padding: 2px;
+            width: (effect-icon.width - 3px) * duration-percent-remaining;
+            height: parent.height * 0.1;
+            // height: 3px;
+            x: 0;
+            y: parent.height;
+            background: bar-color;
+        }
+    }
+}

--- a/game-ui/ui/game_state.slint
+++ b/game-ui/ui/game_state.slint
@@ -48,6 +48,13 @@ export struct Spell {
     prompt: string,
 }
 
+export struct StatusEffect {
+    icon: image,
+    color: int,
+    bar-color: color,
+    duration-percent-remaining: float,
+}
+
 export enum SlotPanelType {
     none,
     item,
@@ -214,6 +221,7 @@ export global GameState {
     in-out property <[InventoryItem]> inventory: [];
     in-out property <[Skill]> skills: [];
     in-out property <[Spell]> spells: [];
+    in-out property <[StatusEffect]> status_effects: [];
     in-out property <[HotbarEntry]> hotbar: [];
     in-out property <bool> show-inventory: false;
     in-out property <bool> show-skills: false;

--- a/packets/src/server/effect.rs
+++ b/packets/src/server/effect.rs
@@ -2,7 +2,7 @@ use crate::TryFromBytes;
 use byteorder::{BigEndian, ReadBytesExt};
 use std::io::Cursor;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Effect {
     pub icon: u16,
     pub color: u8,
@@ -12,6 +12,7 @@ impl TryFromBytes for Effect {
     fn try_from_bytes(bytes: &[u8]) -> anyhow::Result<Self> {
         let mut cursor = Cursor::new(bytes);
         let icon = cursor.read_u16::<BigEndian>()?;
+        // color of the duration bar underneath the effect icon
         let color = cursor.read_u8()?;
 
         Ok(Effect { icon, color })

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -10,7 +10,7 @@ use crate::slint_support::assets::SlintAssetLoader;
 use crate::slint_support::state_bridge::SlintAssetLoaderRes;
 use crate::webui::plugin::{
     AbilityState, ActiveMenuContext, ActiveWindowType, EquipmentState, InventoryState,
-    PlayerProfileState, WorldListState,
+    PlayerProfileState, StatusEffectsState, WorldListState,
 };
 use crate::{MapRendererState, network::PacketOutbox};
 
@@ -58,6 +58,7 @@ pub fn cleanup_ingame_resources(
     world_list: Option<ResMut<WorldListState>>,
     equipment: Option<ResMut<EquipmentState>>,
     profile: Option<ResMut<PlayerProfileState>>,
+    status_effects: Option<ResMut<StatusEffectsState>>,
     hotbar: Option<ResMut<HotbarState>>,
     hotbar_panel: Option<ResMut<HotbarPanelState>>,
     player_attrs: Option<ResMut<PlayerAttributes>>,
@@ -85,6 +86,9 @@ pub fn cleanup_ingame_resources(
     }
     if let Some(mut state) = profile {
         *state = PlayerProfileState::default();
+    }
+    if let Some(mut state) = status_effects {
+        *state = StatusEffectsState::default();
     }
     if let Some(mut state) = hotbar {
         *state = HotbarState::default();

--- a/src/ecs/systems/entities.rs
+++ b/src/ecs/systems/entities.rs
@@ -70,6 +70,7 @@ pub fn spawn_entities_system(
             | SessionEvent::SelfProfile(_)
             | SessionEvent::OtherProfile(_)
             | SessionEvent::WorldList(_) => {}
+            | SessionEvent::StatusEffects(_) => {}
         }
     }
 

--- a/src/events.rs
+++ b/src/events.rs
@@ -107,6 +107,7 @@ impl PlayerAction {
 #[derive(Debug, Clone, Message)]
 pub enum SessionEvent {
     PlayerId(u32),
+    StatusEffects(Vec<server::Effect>),
     WorldMap(server::WorldMap),
     DisplayMenu(server::DisplayMenu),
     DisplayDialog(server::DisplayDialog),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,8 @@ use bevy::prelude::*;
 pub use game_ui::slint_types::{
     ChatMessage, Cooldown, DragDropState, EquipmentSlotData, GameState, HotbarEntry, InputBridge,
     InstallerState, InventoryItem, LegendMarkData, LobbyState, LoginBridge, LoginState, MainWindow,
-    MenuEntry, NpcDialogData, NpcDialogState, ProfileData, SavedLoginItem, ServerItem, SettingsState, Skill,
-    SlotPanelType, Spell, WorldLabel, WorldListMemberUi, WorldMapNode,
+    MenuEntry, NpcDialogData, NpcDialogState, ProfileData, SavedLoginItem, ServerItem, SettingsState,
+    Skill, SlotPanelType, Spell, StatusEffect, WorldLabel, WorldListMemberUi, WorldMapNode,
 };
 
 pub mod app_state;

--- a/src/slint_support/assets.rs
+++ b/src/slint_support/assets.rs
@@ -167,6 +167,10 @@ impl SlintAssetLoader {
         )
     }
 
+    pub fn load_effect_icon(&self, game_files: &GameFiles, sprite_id: u16) -> Result<Image, String> {
+        self.load_spell_icon(game_files, sprite_id)
+    }
+
     pub fn load_world_map_image(
         &self,
         game_files: &GameFiles,

--- a/src/webui/plugin.rs
+++ b/src/webui/plugin.rs
@@ -59,6 +59,7 @@ impl Plugin for UiBridgePlugin {
             .add_message::<UiOutbound>()
             .init_resource::<InventoryState>()
             .init_resource::<AbilityState>()
+            .init_resource::<StatusEffectsState>()
             .init_resource::<WorldListState>()
             .init_resource::<EquipmentState>()
             .init_resource::<PlayerProfileState>()
@@ -1207,12 +1208,41 @@ fn bridge_session_events(
     mut menu_ctx: ResMut<ActiveMenuContext>,
     inv_state: Res<InventoryState>,
     ability_state: Res<AbilityState>,
+    mut status_effects: ResMut<StatusEffectsState>,
     mut profile_state: ResMut<PlayerProfileState>,
     mut show_profile: MessageWriter<crate::slint_plugin::ShowSelfProfileEvent>,
     mut world_list_state: ResMut<WorldListState>,
 ) {
+    const MAX_STATUS_EFFECTS: usize = 20;
+
     for evt in session_events.read() {
         match evt {
+            SessionEvent::StatusEffects(effects) => {
+                for effect in effects.iter().take(MAX_STATUS_EFFECTS) {
+                    if effect.color == 0 {
+                        status_effects.effects.retain(|e| e.icon != effect.icon);
+                        continue;
+                    }
+
+                    if let Some(existing) = status_effects
+                        .effects
+                        .iter_mut()
+                        .find(|e| e.icon == effect.icon)
+                    {
+                        existing.color = effect.color;
+                        continue;
+                    }
+
+                    if status_effects.effects.len() >= MAX_STATUS_EFFECTS {
+                        status_effects.effects.remove(0);
+                    }
+
+                    status_effects.effects.push(StatusEffectUi {
+                        icon: effect.icon,
+                        color: effect.color,
+                    });
+                }
+            }
             SessionEvent::WorldList(pkt) => {
                 world_list_state.raw = Some(pkt.clone());
                 world_list_state.version = world_list_state.version.wrapping_add(1);
@@ -1656,6 +1686,17 @@ impl PlayerProfileState {
 pub struct AbilityState {
     pub skills: Vec<SkillUi>,
     pub spells: Vec<SpellUi>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusEffectUi {
+    pub icon: u16,
+    pub color: u8,
+}
+
+#[derive(Resource, Default, Debug, Clone)]
+pub struct StatusEffectsState {
+    pub effects: Vec<StatusEffectUi>,
 }
 
 #[derive(Resource, Default, Debug, Clone)]


### PR DESCRIPTION
https://github.com/talgonite/talgonite/issues/2
- 2 rows of 10 spell effects
- remaining duration bar is working
- tried to make buffs stay centered at the top of the screen and not clash with existing ui elements no matter the game client window size
<img width="1384" height="908" alt="Screenshot 2026-02-07 at 8 10 06 PM" src="https://github.com/user-attachments/assets/0356d634-39a2-4484-8ed9-f5d664543df3" />
