### PR TITLE
fix: get world-list working

### DIFF
--- a/packets/src/server/world_list.rs
+++ b/packets/src/server/world_list.rs
@@ -11,6 +11,7 @@ use std::io::Read;
 pub enum WorldListColor {
     Guilded = 84,
     NotSure = 88,
+    Unknown = 144,
     WithinLevelRange = 151,
     White = 255,
 }

--- a/src/webui/plugin.rs
+++ b/src/webui/plugin.rs
@@ -1612,6 +1612,7 @@ fn update_world_list_filtered(mut state: ResMut<WorldListState>, mut last_versio
             is_master: m.is_master,
             color: match m.color {
                 packets::server::WorldListColor::Guilded => [1.0, 0.75, 0.25, 1.0], // Gold-ish
+                packets::server::WorldListColor::Unknown => [1.0, 0.596, 0.0, 1.0], // Orange
                 packets::server::WorldListColor::WithinLevelRange => [0.6, 0.6, 1.0, 1.0], // Blue-ish
                 packets::server::WorldListColor::White => [1.0, 1.0, 1.0, 1.0],
                 packets::server::WorldListColor::NotSure => [0.5, 0.5, 0.5, 1.0], // Gray


### PR DESCRIPTION
world list was showing empty on the legends server with this error in the logs
```
2026-02-10T06:58:24.815484Z ERROR Failed to parse packet err=No discriminant in enum `WorldListColor` matches the value `144` len=53 packet="packets::server::world_list::WorldList"
```