### PR TITLE
feat: toggle between single and double click to target mobs/npcs

### DIFF
--- a/game-ui/src/ipc.rs
+++ b/game-ui/src/ipc.rs
@@ -224,6 +224,7 @@ pub enum CoreToUi {
         sfx_volume: f32,
         music_volume: f32,
         scale: f32,
+        npc_interaction_clicks: u8,
         key_bindings: KeyBindingsUi,
     },
 }

--- a/game-ui/ui/components/settings/mouse.slint
+++ b/game-ui/ui/components/settings/mouse.slint
@@ -1,0 +1,31 @@
+import { Theme } from "../../theme.slint";
+import { SettingsState } from "../../settings_state.slint";
+import { VerticalBox, ScrollView, HorizontalBox, CheckBox } from "std-widgets.slint";
+import { SectionHeader, RadioOption } from "widgets.slint";
+
+export component MouseTab inherits VerticalBox {
+    spacing: Theme.spacing-small;
+    padding: Theme.spacing-medium;
+
+    VerticalBox {
+        spacing: Theme.spacing-xsmall;
+        alignment: start;
+        SectionHeader {
+            title: "NPC Interaction";
+        }
+
+        GridLayout {
+            spacing: 4px;
+            // amount of clicks it takes to interact with monsters or NPCs
+            for option[idx] in ["Single Click (classic)", "Double Click"]: RadioOption {
+                label: option;
+                selected: SettingsState.npc-interaction-clicks == idx;
+                horizontal-stretch: 1;
+                clicked => {
+                    SettingsState.npc-interaction-clicks = idx;
+                    SettingsState.npc-interaction-clicks-changed(idx);
+                }
+            }
+        }
+    }
+}

--- a/game-ui/ui/components/settings/panel.slint
+++ b/game-ui/ui/components/settings/panel.slint
@@ -4,6 +4,7 @@ import { ScrollView, VerticalBox, HorizontalBox } from "std-widgets.slint";
 import { MenuButton } from "widgets.slint";
 import { GraphicsTab } from "graphics.slint";
 import { ControlsTab } from "controls.slint";
+import { MouseTab } from "mouse.slint";
 import { BasePanel } from "../base_panel.slint";
 
 export component SettingsPanel inherits BasePanel {
@@ -44,6 +45,14 @@ export component SettingsPanel inherits BasePanel {
                         active-tab = 1;
                     }
                 }
+
+                MenuButton {
+                    label: "Mouse";
+                    selected: active-tab == 2;
+                    clicked => {
+                        active-tab = 2;
+                    }
+                }
             }
 
             Rectangle {
@@ -62,6 +71,12 @@ export component SettingsPanel inherits BasePanel {
                 if active-tab == 1: ScrollView {
                     viewport-width: self.visible-width;
                     ControlsTab {
+                        alignment: start;
+                    }
+                }
+                if active-tab == 2: ScrollView {
+                    viewport-width: self.visible-width;
+                    MouseTab {
                         alignment: start;
                     }
                 }

--- a/game-ui/ui/settings_state.slint
+++ b/game-ui/ui/settings_state.slint
@@ -7,6 +7,7 @@ export global SettingsState {
     in-out property <float> scale: 1.0;  // 1.0 to 5.0
 
     // Key bindings (Primary and Secondary)
+    in-out property <int> npc-interaction-clicks: 0; // 0=Single click, 1=Double click
     in-out property <string> key-move-up: "ArrowUp";
     in-out property <string> key-move-up-2: "";
     in-out property <string> key-move-down: "ArrowDown";
@@ -74,6 +75,7 @@ export global SettingsState {
     callback sfx-volume-changed(float);
     callback music-volume-changed(float);
     callback scale-changed(float);
+    callback npc-interaction-clicks-changed(int);
     callback start-rebind(string, int);
     callback rebind-key(string);
     callback unbind-key(string, int);

--- a/src/settings_types.rs
+++ b/src/settings_types.rs
@@ -28,6 +28,30 @@ fn default_true() -> bool {
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
 pub struct GameplaySettings {
     pub current_server_id: Option<u32>,
+    #[serde(default)]
+    pub npc_interaction_clicks: NpcInteractionClicks,
+}
+
+#[derive(serde::Serialize, serde::Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NpcInteractionClicks {
+    SingleClick = 0,
+    DoubleClick = 1,
+}
+
+impl Default for NpcInteractionClicks {
+    fn default() -> Self {
+        Self::SingleClick
+    }
+}
+
+impl NpcInteractionClicks {
+    pub fn from_u8(mode: u8) -> Self {
+        match mode {
+            0 => Self::SingleClick,
+            _ => Self::DoubleClick,
+        }
+    }
 }
 
 #[derive(Resource, serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -68,6 +92,7 @@ impl Default for Settings {
             },
             gameplay: GameplaySettings {
                 current_server_id: Some(1),
+                npc_interaction_clicks: NpcInteractionClicks::SingleClick,
             },
             key_bindings: KeyBindings::default(),
             servers: vec![ServerEntry {
@@ -101,6 +126,7 @@ impl Settings {
             sfx_volume: self.audio.sfx_volume,
             music_volume: self.audio.music_volume,
             scale: self.graphics.scale,
+            npc_interaction_clicks: self.gameplay.npc_interaction_clicks as u8,
             key_bindings: (&self.key_bindings).into(),
         }
     }

--- a/src/slint_support/callbacks/settings_callbacks.rs
+++ b/src/slint_support/callbacks/settings_callbacks.rs
@@ -50,6 +50,14 @@ pub fn wire_settings_callbacks(slint_app: &MainWindow, tx: Sender<UiToCore>) {
         });
     }
 
+    // Npc Interaction clicks changed
+    {
+        let tx = tx.clone();
+        settings_state.on_npc_interaction_clicks_changed(move |mode| {
+            let _ = tx.send(UiToCore::NpcInteractionClicksChange { mode: mode as u8 });
+        });
+    }
+
     // Start rebind
     {
         let slint_app_weak = slint_app.as_weak();

--- a/src/slint_support/state_bridge.rs
+++ b/src/slint_support/state_bridge.rs
@@ -580,6 +580,7 @@ pub fn apply_core_to_slint(
                 sfx_volume,
                 music_volume,
                 scale,
+                npc_interaction_clicks,
                 key_bindings,
             } => {
                 let settings_state =
@@ -597,6 +598,7 @@ pub fn apply_core_to_slint(
                 settings_state.set_sfx_volume(*sfx_volume);
                 settings_state.set_music_volume(*music_volume);
                 settings_state.set_scale(*scale);
+                settings_state.set_npc_interaction_clicks(*npc_interaction_clicks as i32);
 
                 set_keys!(move_up);
                 set_keys!(move_down);

--- a/src/webui/plugin.rs
+++ b/src/webui/plugin.rs
@@ -325,6 +325,10 @@ fn handle_ui_inbound_ingame(
                 settings.graphics.scale = *scale;
                 zoom_state.set_zoom(*scale);
             }
+            UiToCore::NpcInteractionClicksChange { mode } => {
+                settings.gameplay.npc_interaction_clicks =
+                    crate::settings_types::NpcInteractionClicks::from_u8(*mode);
+            }
             UiToCore::RebindKey {
                 action,
                 new_key,
@@ -968,6 +972,10 @@ fn handle_ui_inbound_login(
             }
             UiToCore::ScaleChange { scale } => {
                 settings.graphics.scale = *scale;
+            }
+            UiToCore::NpcInteractionClicksChange { mode } => {
+                settings.gameplay.npc_interaction_clicks =
+                    crate::settings_types::NpcInteractionClicks::from_u8(*mode);
             }
             UiToCore::RebindKey {
                 action,


### PR DESCRIPTION
the retail DA client only requires a singe click to interacting with a merchant, npc, or monster/mob. talgonite was hard coded to require a double click. this PR adds a settings UI option to configure the amount of clicks required to interact with a NPC/mob that defaults to single click (classic).